### PR TITLE
Updated documentation URL

### DIFF
--- a/README
+++ b/README
@@ -1,4 +1,4 @@
-Docs at http://www.jperla.com/blog/write-bug-free-javascript-with-pebbles
+Docs at http://www.jperla.com/blog/post/write-bug-free-javascript-with-pebbles
 
 Goals of Pebbles:
  * so easy that a designer could write complicated AJAX!


### PR DESCRIPTION
Corrected the documentation URL in the README.  Apparently "post" is now necessary in the blog link.
